### PR TITLE
Update Base RPC

### DIFF
--- a/packages/chains/src/base.ts
+++ b/packages/chains/src/base.ts
@@ -7,10 +7,10 @@ export const base = {
   nativeCurrency: { name: 'Base', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://developer-access-mainnet.base.org'],
+      http: ['https://mainnet.base.org'],
     },
     public: {
-      http: ['https://developer-access-mainnet.base.org'],
+      http: ['https://mainnet.base.org'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
## Description

[The Base RPC has been updated](https://docs.base.org/network-information/), and using the old one gives users warnings in some wallets. 

## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
